### PR TITLE
feat: add dynamic capsule support

### DIFF
--- a/rearch/src/capsule_reader.rs
+++ b/rearch/src/capsule_reader.rs
@@ -1,25 +1,22 @@
-use std::{
-    any::{Any, TypeId},
-    collections::HashMap,
-};
+use std::{any::Any, collections::HashMap};
 
-use crate::{Capsule, CapsuleData, ContainerWriteTxn};
+use crate::{Capsule, CapsuleData, ContainerWriteTxn, CreateInternalKey, InternalKey};
 
 /// Allows you to read the current data of capsules based on the given state of the container txn.
-pub enum CapsuleReader<'scope, 'total> {
+pub enum CapsuleReader<'key, 'scope, 'total> {
     // For normal operation
     Normal {
-        id: TypeId,
+        id: &'key InternalKey,
         txn: &'scope mut ContainerWriteTxn<'total>,
     },
     // To enable easy mocking in testing
     Mock {
-        mocks: HashMap<TypeId, Box<dyn CapsuleData>>,
+        mocks: HashMap<InternalKey, Box<dyn CapsuleData>>,
     },
 }
 
-impl<'scope, 'total> CapsuleReader<'scope, 'total> {
-    pub(crate) fn new(id: TypeId, txn: &'scope mut ContainerWriteTxn<'total>) -> Self {
+impl<'key, 'scope, 'total> CapsuleReader<'key, 'scope, 'total> {
+    pub(crate) fn new(id: &'key InternalKey, txn: &'scope mut ContainerWriteTxn<'total>) -> Self {
         Self::Normal { id, txn }
     }
 
@@ -32,15 +29,15 @@ impl<'scope, 'total> CapsuleReader<'scope, 'total> {
     pub fn get<C: Capsule>(&mut self, capsule: C) -> C::Data {
         match self {
             CapsuleReader::Normal { id, txn } => {
-                let (this, other) = (*id, TypeId::of::<C>());
+                let (this, other) = (id.clone(), capsule.internal_key());
                 if this == other {
                     return txn.try_read(&capsule).unwrap_or_else(|| {
                         let name = std::any::type_name::<C>();
                         panic!(
-                            "Capsule {name} tried to read itself on its first build! {} {} {}",
+                            "{name} ({id:?}) tried to read itself on its first build! {} {} {}",
                             "This is disallowed since the capsule doesn't have data to read yet.",
-                            "To avoid this issue, wrap the `read({name})` call in an if statement",
-                            "with the builtin \"is first build\" side effect."
+                            "To avoid this issue, wrap the `get()` call in an if statement",
+                            "with the builtin \"is_first_build\" side effect."
                         );
                     });
                 }
@@ -51,12 +48,12 @@ impl<'scope, 'total> CapsuleReader<'scope, 'total> {
                 data
             }
             CapsuleReader::Mock { mocks } => {
-                let id = TypeId::of::<C>();
+                let id = capsule.internal_key();
                 let any: Box<dyn Any> = mocks
                     .get(&id)
                     .unwrap_or_else(|| {
                         panic!(
-                            "Mock CapsuleReader was used to read {} {}",
+                            "Mock CapsuleReader was used to read {} ({id:?}) {}",
                             std::any::type_name::<C>(),
                             "when it was not included in the mock!"
                         );
@@ -70,7 +67,7 @@ impl<'scope, 'total> CapsuleReader<'scope, 'total> {
 }
 
 #[cfg(feature = "better-api")]
-impl<A: Capsule> FnOnce<(A,)> for CapsuleReader<'_, '_> {
+impl<A: Capsule> FnOnce<(A,)> for CapsuleReader<'_, '_, '_> {
     type Output = A::Data;
     extern "rust-call" fn call_once(mut self, args: (A,)) -> Self::Output {
         self.call_mut(args)
@@ -78,14 +75,14 @@ impl<A: Capsule> FnOnce<(A,)> for CapsuleReader<'_, '_> {
 }
 
 #[cfg(feature = "better-api")]
-impl<A: Capsule> FnMut<(A,)> for CapsuleReader<'_, '_> {
+impl<A: Capsule> FnMut<(A,)> for CapsuleReader<'_, '_, '_> {
     extern "rust-call" fn call_mut(&mut self, args: (A,)) -> Self::Output {
         self.get(args.0)
     }
 }
 
 #[derive(Clone, Default)]
-pub struct MockCapsuleReaderBuilder(HashMap<TypeId, Box<dyn CapsuleData>>);
+pub struct MockCapsuleReaderBuilder(HashMap<InternalKey, Box<dyn CapsuleData>>);
 
 impl MockCapsuleReaderBuilder {
     #[must_use]
@@ -94,13 +91,13 @@ impl MockCapsuleReaderBuilder {
     }
 
     #[must_use]
-    pub fn set<C: Capsule>(mut self, _capsule: &C, data: C::Data) -> Self {
-        self.0.insert(TypeId::of::<C>(), Box::new(data));
+    pub fn set<C: Capsule>(mut self, capsule: &C, data: C::Data) -> Self {
+        self.0.insert(capsule.internal_key(), Box::new(data));
         self
     }
 
     #[must_use]
-    pub fn build(self) -> CapsuleReader<'static, 'static> {
+    pub fn build(self) -> CapsuleReader<'static, 'static, 'static> {
         CapsuleReader::Mock { mocks: self.0 }
     }
 }

--- a/rearch/src/txn.rs
+++ b/rearch/src/txn.rs
@@ -1,32 +1,26 @@
 use concread::hashmap::{HashMapReadTxn, HashMapWriteTxn};
-use std::{
-    any::{Any, TypeId},
-    cell::OnceCell,
-    collections::HashSet,
-};
+use std::{any::Any, cell::OnceCell, collections::HashSet};
 
-use crate::{Capsule, CapsuleData, CapsuleManager, CapsuleRebuilder, EXCLUSIVE_OWNER_MSG};
+use crate::{
+    Capsule, CapsuleData, CapsuleManager, CapsuleRebuilder, CreateInternalKey, InternalKey,
+    EXCLUSIVE_OWNER_MSG,
+};
 
 #[allow(clippy::module_name_repetitions)]
 pub struct ContainerReadTxn<'a> {
-    data: HashMapReadTxn<'a, TypeId, Box<dyn CapsuleData>>,
+    data: HashMapReadTxn<'a, InternalKey, Box<dyn CapsuleData>>,
 }
 
 impl<'a> ContainerReadTxn<'a> {
-    pub(crate) fn new(data: HashMapReadTxn<'a, TypeId, Box<dyn CapsuleData>>) -> Self {
+    pub(crate) fn new(data: HashMapReadTxn<'a, InternalKey, Box<dyn CapsuleData>>) -> Self {
         Self { data }
     }
 }
 
 impl ContainerReadTxn<'_> {
     #[must_use]
-    pub fn try_read<C: Capsule>(&self, _capsule: &C) -> Option<C::Data> {
-        self.try_read_raw::<C>()
-    }
-
-    /// Tries a capsule read, but doesn't require an instance of the capsule itself
-    fn try_read_raw<C: Capsule>(&self) -> Option<C::Data> {
-        let id = TypeId::of::<C>();
+    pub fn try_read<C: Capsule>(&self, capsule: &C) -> Option<C::Data> {
+        let id = capsule.internal_key();
         self.data.get(&id).map(|data| {
             let data: Box<dyn Any> = data.clone();
             *data
@@ -39,14 +33,14 @@ impl ContainerReadTxn<'_> {
 #[allow(clippy::module_name_repetitions)]
 pub struct ContainerWriteTxn<'a> {
     pub(crate) rebuilder: CapsuleRebuilder,
-    pub(crate) data: HashMapWriteTxn<'a, TypeId, Box<dyn CapsuleData>>,
-    nodes: &'a mut std::collections::HashMap<TypeId, CapsuleManager>,
+    pub(crate) data: HashMapWriteTxn<'a, InternalKey, Box<dyn CapsuleData>>,
+    nodes: &'a mut std::collections::HashMap<InternalKey, CapsuleManager>,
 }
 
 impl<'a> ContainerWriteTxn<'a> {
     pub(crate) fn new(
-        data: HashMapWriteTxn<'a, TypeId, Box<dyn CapsuleData>>,
-        nodes: &'a mut std::collections::HashMap<TypeId, CapsuleManager>,
+        data: HashMapWriteTxn<'a, InternalKey, Box<dyn CapsuleData>>,
+        nodes: &'a mut std::collections::HashMap<InternalKey, CapsuleManager>,
         rebuilder: CapsuleRebuilder,
     ) -> Self {
         Self {
@@ -60,25 +54,36 @@ impl<'a> ContainerWriteTxn<'a> {
 impl ContainerWriteTxn<'_> {
     #[allow(clippy::missing_panics_doc)]
     pub fn read_or_init<C: Capsule>(&mut self, capsule: C) -> C::Data {
-        let id = TypeId::of::<C>();
+        let id = capsule.internal_key();
+
         if !self.data.contains_key(&id) {
             #[cfg(feature = "logging")]
             log::debug!("Initializing {} ({:?})", std::any::type_name::<C>(), id);
 
             self.build_capsule(capsule);
         }
-        self.try_read_raw::<C>()
+
+        self.try_read_raw::<C>(&id)
             .expect("Data should be present due to checking/building capsule above")
     }
 
     #[must_use]
-    pub fn try_read<C: Capsule>(&self, _capsule: &C) -> Option<C::Data> {
-        self.try_read_raw::<C>()
+    pub fn try_read<C: Capsule>(&self, capsule: &C) -> Option<C::Data> {
+        self.try_read_raw::<C>(&capsule.internal_key())
+    }
+
+    fn try_read_raw<C: Capsule>(&self, id: &InternalKey) -> Option<C::Data> {
+        self.data.get(&id).map(|data| {
+            let data: Box<dyn Any> = data.clone();
+            *data
+                .downcast::<C::Data>()
+                .expect("Types should be properly enforced due to generics")
+        })
     }
 
     /// Forcefully disposes only the requested node, cleaning up the node's direct dependencies.
     /// Panics if the node or one of its dependencies is not in the graph.
-    pub(crate) fn dispose_node(&mut self, id: TypeId) {
+    pub(crate) fn dispose_node(&mut self, id: &InternalKey) {
         self.data.remove(&id);
         self.nodes
             .remove(&id)
@@ -86,33 +91,39 @@ impl ContainerWriteTxn<'_> {
             .dependencies
             .iter()
             .for_each(|dep| {
-                self.node_or_panic(*dep).dependents.remove(&id);
+                self.node_or_panic(dep).dependents.remove(&id);
             });
     }
 
-    pub(crate) fn add_dependency_relationship(&mut self, dependency: TypeId, dependent: TypeId) {
-        self.node_or_panic(dependency).dependents.insert(dependent);
-        self.node_or_panic(dependent)
+    pub(crate) fn add_dependency_relationship(
+        &mut self,
+        dependency: InternalKey,
+        dependent: InternalKey,
+    ) {
+        self.node_or_panic(&dependency)
+            .dependents
+            .insert(dependent.clone());
+        self.node_or_panic(&dependent)
             .dependencies
             .insert(dependency);
     }
 
     /// Forcefully builds the capsule with the supplied id. Panics if node is not in the graph
-    pub(crate) fn build_capsule_or_panic(&mut self, id: TypeId) {
+    pub(crate) fn build_capsule_or_panic(&mut self, id: &InternalKey) {
         let self_changed = self.build_single_node(id);
         if !self_changed {
             return;
         }
 
-        let mut build_order_stack = self.create_build_order_stack(id);
+        let mut build_order_stack = self.create_build_order_stack(id.clone());
         build_order_stack.pop(); // we built id already above, and id is the head of the stack
         let disposable_nodes = self.get_disposable_nodes_from_build_order_stack(&build_order_stack);
 
         let mut changed_nodes = HashSet::new();
-        changed_nodes.insert(id);
+        changed_nodes.insert(id.clone());
 
         for curr_id in build_order_stack.into_iter().rev() {
-            let node = self.node_or_panic(curr_id);
+            let node = self.node_or_panic(&curr_id);
 
             let have_deps_changed = node
                 .dependencies
@@ -126,10 +137,10 @@ impl ContainerWriteTxn<'_> {
                 // Note: dependency/dependent relationships will be ok after this,
                 // since we are disposing all dependents in the build order,
                 // because we are adding this node to changedNodes
-                self.dispose_single_node(curr_id);
+                self.dispose_single_node(&curr_id);
                 changed_nodes.insert(curr_id);
             } else {
-                let did_node_change = self.build_single_node(curr_id);
+                let did_node_change = self.build_single_node(&curr_id);
                 if did_node_change {
                     changed_nodes.insert(curr_id);
                 }
@@ -139,7 +150,7 @@ impl ContainerWriteTxn<'_> {
 
     pub(crate) fn take_capsule_and_side_effect(
         &mut self,
-        id: TypeId,
+        id: &InternalKey,
     ) -> (Box<dyn Any + Send>, OnceCell<Box<dyn Any + Send>>) {
         let node = self.node_or_panic(id);
         let capsule = std::mem::take(&mut node.capsule).expect(EXCLUSIVE_OWNER_MSG);
@@ -149,7 +160,7 @@ impl ContainerWriteTxn<'_> {
 
     pub(crate) fn yield_capsule_and_side_effect(
         &mut self,
-        id: TypeId,
+        id: &InternalKey,
         capsule: Box<dyn Any + Send>,
         side_effect: OnceCell<Box<dyn Any + Send>>,
     ) {
@@ -162,58 +173,47 @@ impl ContainerWriteTxn<'_> {
         node.side_effect = Some(side_effect);
     }
 
-    pub(crate) fn side_effect(&mut self, id: TypeId) -> &mut OnceCell<Box<dyn Any + Send>> {
+    pub(crate) fn side_effect(&mut self, id: &InternalKey) -> &mut OnceCell<Box<dyn Any + Send>> {
         self.node_or_panic(id)
             .side_effect
             .as_mut()
             .expect(EXCLUSIVE_OWNER_MSG)
     }
 
-    /// Tries a capsule read, but doesn't require an instance of the capsule itself
-    fn try_read_raw<C: Capsule>(&self) -> Option<C::Data> {
-        let id = TypeId::of::<C>();
-        self.data.get(&id).map(|data| {
-            let data: Box<dyn Any> = data.clone();
-            *data
-                .downcast::<C::Data>()
-                .expect("Types should be properly enforced due to generics")
-        })
-    }
-
     /// Triggers a first build or rebuild for the supplied capsule
     fn build_capsule<C: Capsule>(&mut self, capsule: C) {
-        let id = TypeId::of::<C>();
+        let id = capsule.internal_key();
 
-        if let std::collections::hash_map::Entry::Vacant(e) = self.nodes.entry(id) {
+        if let std::collections::hash_map::Entry::Vacant(e) = self.nodes.entry(id.clone()) {
             e.insert(CapsuleManager::new(capsule));
         }
 
-        self.build_capsule_or_panic(id);
+        self.build_capsule_or_panic(&id);
     }
 
     /// Gets the requested node if it is in the graph
-    fn node(&mut self, id: TypeId) -> Option<&mut CapsuleManager> {
+    fn node(&mut self, id: &InternalKey) -> Option<&mut CapsuleManager> {
         self.nodes.get_mut(&id)
     }
 
     /// Gets the requested node or panics if it is not in the graph
-    fn node_or_panic(&mut self, id: TypeId) -> &mut CapsuleManager {
+    fn node_or_panic(&mut self, id: &InternalKey) -> &mut CapsuleManager {
         self.node(id)
             .expect("Requested node should be in the graph")
     }
 
     /// Builds only the requested node. Panics if the node is not in the graph
-    fn build_single_node(&mut self, id: TypeId) -> bool {
+    fn build_single_node(&mut self, id: &InternalKey) -> bool {
         // Remove old dependency info since it may change on this build
         // We use std::mem::take below to prevent needing a clone on the existing dependencies
         let node = self.node_or_panic(id);
         let old_deps = std::mem::take(&mut node.dependencies);
         for dep in old_deps {
-            self.node_or_panic(dep).dependents.remove(&id);
+            self.node_or_panic(&dep).dependents.remove(&id);
         }
 
         // Trigger the build (which also populates its new dependencies in self)
-        (self.node_or_panic(id).build)(self)
+        (self.node_or_panic(id).build)(id.clone(), self)
     }
 
     /// Disposes just the supplied node, and *attempts* to clean up the node's direct dependencies.
@@ -221,7 +221,7 @@ impl ContainerWriteTxn<'_> {
     /// as an idempotent node getting disposed in that method may have dependencies that
     /// were already disposed from the graph.
     /// In all other cases, [`dispose_node`] is likely the proper method to use.
-    fn dispose_single_node(&mut self, id: TypeId) {
+    fn dispose_single_node(&mut self, id: &InternalKey) {
         self.data.remove(&id);
         self.nodes
             .remove(&id)
@@ -229,7 +229,7 @@ impl ContainerWriteTxn<'_> {
             .dependencies
             .iter()
             .for_each(|dep| {
-                if let Some(node) = self.node(*dep) {
+                if let Some(node) = self.node(dep) {
                     node.dependents.remove(&id);
                 }
             });
@@ -237,7 +237,7 @@ impl ContainerWriteTxn<'_> {
 
     /// Creates the start node's dependent subgraph build order, including start, *as a stack*.
     /// Thus, proper iteration order is done by popping off of the stack (in reverse order)!
-    fn create_build_order_stack(&mut self, start: TypeId) -> Vec<TypeId> {
+    fn create_build_order_stack(&mut self, start: InternalKey) -> Vec<InternalKey> {
         // We need some more information alongside each node in order to do the topological sort
         // - False is for the first visit, which adds all deps to be visited and then self again
         // - True is for the second visit, which pushes node to the build order
@@ -251,12 +251,12 @@ impl ContainerWriteTxn<'_> {
                 build_order_stack.push(node);
             } else if !visited.contains(&node) {
                 // New node, so mark this node to be added later and process dependents
-                visited.insert(node);
-                to_visit_stack.push((true, node)); // mark node to be added to build order later
-                self.node_or_panic(node)
+                visited.insert(node.clone());
+                to_visit_stack.push((true, node.clone())); // mark node to be added to build order later
+                self.node_or_panic(&node)
                     .dependents
                     .iter()
-                    .copied()
+                    .cloned()
                     .filter(|dep| !visited.contains(dep))
                     .for_each(|dep| to_visit_stack.push((false, dep)));
             }
@@ -273,16 +273,16 @@ impl ContainerWriteTxn<'_> {
     /// some fat through gc.
     fn get_disposable_nodes_from_build_order_stack(
         &mut self,
-        build_order_stack: &Vec<TypeId>,
-    ) -> HashSet<TypeId> {
+        build_order_stack: &Vec<InternalKey>,
+    ) -> HashSet<InternalKey> {
         let mut disposable = HashSet::new();
 
         for id in build_order_stack {
-            let node = self.node_or_panic(*id);
+            let node = self.node_or_panic(id);
             let dependents_all_disposable =
                 node.dependents.iter().all(|dep| disposable.contains(dep));
             if node.is_idempotent() && dependents_all_disposable {
-                disposable.insert(*id);
+                disposable.insert(id.clone());
             }
         }
 


### PR DESCRIPTION
Fixes #9 

TODO:
- [ ] Fix all clippy lints with --no-default-features and also --features=logging
- [ ] Switch `InternalKey` usages to `Arc<InternalKey>` so we can use cheap `Arc::clone`s everywhere and always have an owned instance instead of battling references and trying to minimize clones
- [ ] Add dynamic capsules test (include static capsules in this mix)