### PR TITLE
refactor!: rework internal modules, features, and code docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,13 +31,13 @@ jobs:
       - name: Code analysis (--no-default-features)
         run: cargo clippy --workspace --no-default-features -- -D warnings
       - name: Code analysis (--all-features)
-        if: matrix.toolchain == 'nightly' # better-api requires nightly
+        if: matrix.toolchain == 'nightly' # experimental-api requires nightly
         run: cargo clippy --workspace --all-features -- -D warnings
 
       - name: Run tests (--no-default-features)
         run: cargo test --workspace --no-default-features
       - name: Run tests (--all-features)
-        if: matrix.toolchain == 'nightly' # better-api requires nightly
+        if: matrix.toolchain == 'nightly' # experimental-api requires nightly
         run: cargo test --workspace --all-features
 
       - name: Run tests under WASI

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Also, there is some WIP [documentation] that will help you learn the core concep
 The MSRV is currently 1.74.0 and may change in any new ReArch version/release.
 
 It is also worth mentioning that the example shown in "In a Nutshell" above requires nightly
-for `unboxed_closures` and `fn_traits`, which is feature-gated under the `better-api` feature.
+for `unboxed_closures` and `fn_traits`, which is feature-gated under the `experimental-api` feature.
 Once `unboxed_closures` and `fn_traits` stabilize,
 this nightly syntax will be the preferred syntax,
 and this will no longer be feature-gated.

--- a/rearch/Cargo.toml
+++ b/rearch/Cargo.toml
@@ -28,5 +28,8 @@ default = []
 # Enable logging with `log`
 logging = ["dep:log"]
 
-# Enables the cleaner/better api, but unfortunately requires nightly
-better-api = []
+# *EXPERIMENTAL* Enables the cleaner/better api, but unfortunately requires nightly
+experimental-api = []
+
+# *EXPERIMENTAL* Enables ContainerReadTxn, ContainerWriteTxn, and associated methods
+experimental-txn = []

--- a/rearch/src/capsule_key.rs
+++ b/rearch/src/capsule_key.rs
@@ -8,10 +8,12 @@ use std::{
 use crate::Capsule;
 
 /// Represents a key for a capsule.
+/// The [`Default`] impl is for static capsules and the [`From`] impl is for dynamic capsules.
+///
 /// You'll only ever need to use this directly if you are making dynamic (runtime) capsules.
-/// Most applications are just fine with static/function capsules.
+/// Most applications are just fine with static (function) capsules.
 /// If you are making an incremental computation focused application,
-/// then you may need dynamic capsules.
+/// then you may need dynamic capsules and the [`From`] impl.
 #[derive(Default)]
 pub struct CapsuleKey(CapsuleKeyType);
 impl<T: Hash + Eq + Debug + Send + Sync + 'static> From<T> for CapsuleKey {
@@ -76,9 +78,8 @@ impl PartialEq for dyn DynamicCapsuleKey {
 }
 impl Eq for dyn DynamicCapsuleKey {}
 
-#[allow(clippy::redundant_pub_crate)] // false positive
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub(crate) struct CapsuleId {
+pub struct CapsuleId {
     // We need to have a copy of the capsule's type to include in the Hash + Eq
     // so that if two capsules of different types have the same bytes as their key,
     // they won't be kept under the same entry in the map.
@@ -86,8 +87,7 @@ pub(crate) struct CapsuleId {
     capsule_key: CapsuleKeyType,
 }
 
-#[allow(clippy::redundant_pub_crate)] // false positive
-pub(crate) trait CreateCapsuleId {
+pub trait CreateCapsuleId {
     fn id(&self) -> CapsuleId;
 }
 impl<C: Capsule> CreateCapsuleId for C {

--- a/rearch/src/capsule_reader.rs
+++ b/rearch/src/capsule_reader.rs
@@ -80,7 +80,7 @@ impl<'scope, 'total> CapsuleReader<'scope, 'total> {
     }
 }
 
-#[cfg(feature = "better-api")]
+#[cfg(feature = "experimental-api")]
 impl<A: Capsule> FnOnce<(A,)> for CapsuleReader<'_, '_>
 where
     A::Data: Clone,
@@ -91,7 +91,7 @@ where
     }
 }
 
-#[cfg(feature = "better-api")]
+#[cfg(feature = "experimental-api")]
 impl<A: Capsule> FnMut<(A,)> for CapsuleReader<'_, '_>
 where
     A::Data: Clone,

--- a/rearch/src/side_effect_registrar.rs
+++ b/rearch/src/side_effect_registrar.rs
@@ -7,8 +7,6 @@ use crate::{
 /// Registers the given side effect and returns its build api.
 /// You can only call register once on purpose (it consumes self);
 /// to register multiple side effects, simply pass them in together!
-/// If you have an idempotent capsule that you wish to make non-idempotent,
-/// simply call `register()` with no arguments (or use the `as_listener()` side effect).
 pub struct SideEffectRegistrar<'a> {
     side_effect: &'a mut OnceCell<Box<dyn Any + Send>>,
     side_effect_state_mutater: SideEffectStateMutater,
@@ -73,7 +71,7 @@ impl<'a> SideEffectRegistrar<'a> {
 }
 
 // One arg register needs its own impl because tuples with one effect don't impl SideEffect
-#[cfg(feature = "better-api")]
+#[cfg(feature = "experimental-api")]
 impl<'a, S: SideEffect> FnOnce<(S,)> for SideEffectRegistrar<'a> {
     type Output = S::Api<'a>;
     extern "rust-call" fn call_once(self, (effect,): (S,)) -> Self::Output {
@@ -83,7 +81,7 @@ impl<'a, S: SideEffect> FnOnce<(S,)> for SideEffectRegistrar<'a> {
 macro_rules! generate_side_effect_registrar_fn_impl {
     ($($types:ident),*) => {
         #[allow(unused_parens, non_snake_case)]
-        #[cfg(feature = "better-api")]
+        #[cfg(feature = "experimental-api")]
         impl<'a, $($types: SideEffect),*> FnOnce<($($types,)*)> for SideEffectRegistrar<'a> {
             type Output = ($($types::Api<'a>),*);
             extern "rust-call" fn call_once(self, args: ($($types),*)) -> Self::Output {


### PR DESCRIPTION
**MIGRATION**:
- `better-api` feature has been renamed to `experimental-api`
- `Container::with_write_txn` and `Container::with_read_txn` are now feature-gated under `experimental-txn` feature