### PR TITLE
refactor!: remove `CapsuleReader::get`

### DIFF
--- a/examples/axum/src/main.rs
+++ b/examples/axum/src/main.rs
@@ -57,7 +57,7 @@ mod todo_db {
     where
         F: FnOnce(ReadOnlyTable<'_, u128, &str>) -> Result<R, redb::Error>,
     {
-        let db = get.get(db_capsule);
+        let db = Arc::clone(get.as_ref(db_capsule));
         move |with_table| {
             let txn = db.begin_read()?;
             let table = txn.open_table(TODOS_TABLE)?;
@@ -71,7 +71,7 @@ mod todo_db {
     where
         F: FnOnce(Table<'_, '_, u128, &str>) -> Result<R, redb::Error>,
     {
-        let db = get.get(db_capsule);
+        let db = Arc::clone(get.as_ref(db_capsule));
         move |with_table| {
             let txn = db.begin_write()?;
             let table = txn.open_table(TODOS_TABLE)?;
@@ -84,7 +84,7 @@ mod todo_db {
     pub(super) fn read_todo_capsule(
         CapsuleHandle { mut get, .. }: CapsuleHandle,
     ) -> impl CData + Fn(Uuid) -> Result<Option<String>, redb::Error> {
-        let with_txn = get.get(with_read_txn_capsule);
+        let with_txn = get.as_ref(with_read_txn_capsule).clone();
         move |uuid| {
             with_txn(move |table| {
                 let content = table.get(uuid.as_u128())?.map(|s| s.value().to_owned());
@@ -96,7 +96,7 @@ mod todo_db {
     pub(super) fn create_todo_capsule(
         CapsuleHandle { mut get, .. }: CapsuleHandle,
     ) -> impl CData + Fn(String) -> Result<TodoWithId, redb::Error> {
-        let with_txn = get.get(with_write_txn_capsule);
+        let with_txn = get.as_ref(with_write_txn_capsule).clone();
         move |content| {
             with_txn(move |mut table| {
                 let uuid = Uuid::new_v4();
@@ -109,7 +109,7 @@ mod todo_db {
     pub(super) fn delete_todo_capsule(
         CapsuleHandle { mut get, .. }: CapsuleHandle,
     ) -> impl CData + Fn(Uuid) -> Result<Option<String>, redb::Error> {
-        let with_txn = get.get(with_write_txn_capsule);
+        let with_txn = get.as_ref(with_write_txn_capsule).clone();
         move |uuid| {
             with_txn(move |mut table| {
                 let removed_todo = table.remove(uuid.as_u128())?.map(|s| s.value().to_owned());
@@ -121,7 +121,7 @@ mod todo_db {
     pub(super) fn list_todos_capsule(
         CapsuleHandle { mut get, .. }: CapsuleHandle,
     ) -> impl CData + Fn() -> Result<Vec<TodoWithId>, redb::Error> {
-        let with_txn = get.get(with_read_txn_capsule);
+        let with_txn = get.as_ref(with_read_txn_capsule).clone();
         move || {
             with_txn(|table| {
                 table

--- a/examples/fibonacci/src/main.rs
+++ b/examples/fibonacci/src/main.rs
@@ -9,7 +9,7 @@ impl Capsule for FibonacciCapsule {
         match n {
             0 => 0,
             1 => 1,
-            n => get.get(Self(n - 1)) + get.get(Self(n - 2)),
+            n => *get.as_ref(Self(n - 1)) + get.as_ref(Self(n - 2)),
         }
     }
 

--- a/examples/simple-demo/src/main.rs
+++ b/examples/simple-demo/src/main.rs
@@ -6,7 +6,7 @@ fn count_capsule(_: CapsuleHandle) -> i32 {
 }
 
 fn count_plus_one_capsule(CapsuleHandle { mut get, .. }: CapsuleHandle) -> i32 {
-    get.get(count_capsule) + 1
+    get.as_ref(count_capsule) + 1
 }
 
 fn crazy_capsule(_: CapsuleHandle) -> &'static str {
@@ -16,16 +16,16 @@ fn crazy_capsule(_: CapsuleHandle) -> &'static str {
 fn big_string_factory(
     CapsuleHandle { mut get, .. }: CapsuleHandle,
 ) -> impl CData + Fn(&str) -> String {
-    let count = get.get(count_capsule);
-    let count_plus_one = get.get(count_plus_one_capsule);
-    let crazy = get.get(crazy_capsule);
+    let count = *get.as_ref(count_capsule);
+    let count_plus_one = *get.as_ref(count_plus_one_capsule);
+    let crazy = *get.as_ref(crazy_capsule);
     move |other| {
         format!("param: {other}, count: {count}, count_plus_one: {count_plus_one}, crazy: {crazy}")
     }
 }
 
 fn uses_factory_capsule(CapsuleHandle { mut get, .. }: CapsuleHandle) -> String {
-    get.get(big_string_factory)("argument supplied to factory")
+    get.as_ref(big_string_factory)("argument supplied to factory")
 }
 
 fn stateful_capsule(CapsuleHandle { register, .. }: CapsuleHandle) -> (u32, impl CData + Fn(u32)) {


### PR DESCRIPTION
**MIGRATION**: replace `get.get(capsule)` with `get.as_ref(capsule).clone()`