### PR TITLE
refactor!: rewrite old CapsuleKey as trait alias

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        toolchain: ["1.74.0", "nightly"]
+        toolchain: ["1.75.0", "nightly"]
 
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Also, there is some WIP [documentation] that will help you learn the core concep
 
 
 ## Minimum Supported Rust Version (MSRV)
-The MSRV of `rearch` is currently 1.74.0 and may change in any new ReArch version/release.
+The MSRV of `rearch` is currently 1.75.0 and may change in any new ReArch version/release.
 The MSRV of other crates in this repo will be the latest stable release for the foreseeable future.
 
 It is also worth mentioning that the example shown in "In a Nutshell" above requires nightly

--- a/examples/fibonacci/src/main.rs
+++ b/examples/fibonacci/src/main.rs
@@ -17,8 +17,8 @@ impl Capsule for FibonacciCapsule {
         old == new
     }
 
-    fn key(&self) -> CapsuleKey {
-        self.0.into()
+    fn key(&self) -> impl CapsuleKey {
+        self.0
     }
 }
 

--- a/examples/large-list/src/main.rs
+++ b/examples/large-list/src/main.rs
@@ -17,8 +17,8 @@ impl Capsule for ListElementViewCapsule {
         old == new
     }
 
-    fn key(&self) -> CapsuleKey {
-        self.0.into()
+    fn key(&self) -> impl CapsuleKey {
+        self.0
     }
 }
 

--- a/rearch/src/lib.rs
+++ b/rearch/src/lib.rs
@@ -56,10 +56,9 @@ pub trait Capsule: Send + 'static {
     /// which is for static capsules.
     /// If you specifically need dynamic capsules,
     /// such as for an incremental computation focused application,
-    /// you will need to implement this function.
-    /// See [`CapsuleKey`] for more.
-    fn key(&self) -> CapsuleKey {
-        CapsuleKey::default()
+    /// you will need to implement this function and return your capsule's key.
+    fn key(&self) -> impl CapsuleKey {
+        // NOTE: this default impl implicitly returns `()` (for static capsules)
     }
 }
 impl<T, F> Capsule for F
@@ -912,8 +911,8 @@ mod tests {
                 old == new
             }
 
-            fn key(&self) -> CapsuleKey {
-                self.0.into()
+            fn key(&self) -> impl CapsuleKey {
+                self.0
             }
         }
 
@@ -935,8 +934,8 @@ mod tests {
                 old == new
             }
 
-            fn key(&self) -> CapsuleKey {
-                self.0.into()
+            fn key(&self) -> impl CapsuleKey {
+                self.0
             }
         }
         struct B(u8);
@@ -951,8 +950,8 @@ mod tests {
                 old == new
             }
 
-            fn key(&self) -> CapsuleKey {
-                self.0.into()
+            fn key(&self) -> impl CapsuleKey {
+                self.0
             }
         }
 
@@ -979,8 +978,8 @@ mod tests {
                 old == new
             }
 
-            fn key(&self) -> CapsuleKey {
-                self.0.into()
+            fn key(&self) -> impl CapsuleKey {
+                self.0
             }
         }
         fn sink(CapsuleHandle { mut get, .. }: CapsuleHandle) -> (u8, u8) {


### PR DESCRIPTION
This removes issues the old CapsuleKey faced, such as no Hash impl.

Fixes #39